### PR TITLE
Bump litellm from 1.82.2 to 1.83.0 (CVE-2026-35030)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ dependencies = [
     "fastjsonschema (>=2.21.2,<3.0.0)",
     "genai-prices==0.0.55", # pin version due to frequent API changes
     "jinja2 (>=3.1.5,<4.0.0)",
-    "litellm==1.82.2", # pin version due to occasional instability between patches and minor versions
+    "litellm==1.83.0", # pin version due to occasional instability between patches and minor versions (bumped for CVE-2026-35030)
     "lxml (>=5.4.0,<7.0.0)",
     "openai==2.21.0", # pinned version for stable compatibility with litellm (after issue with 1.100.0)
     "pillow (>=11.3.0,<12.0.0)",


### PR DESCRIPTION
## Summary

Bump the pinned `litellm` version from `1.82.2` to `1.83.0` to fix **CVE-2026-35030** (GHSA-jjhc-v7c2-5hh6).

## Vulnerability

`litellm < 1.83.0` has an OIDC authentication bypass via JWT cache collision. The OIDC userinfo caching mechanism uses only the first 20 characters of a JWT token as the cache key. Since tokens generated by the same signing algorithm share identical initial characters, an attacker can craft a malicious token matching a legitimate user's cached token prefix, gaining unauthorized access.

The fix in 1.83.0 changes the cache key to use the full hash of the JWT token.

## Reference

- https://github.com/advisories/GHSA-jjhc-v7c2-5hh6
- https://nvd.nist.gov/vuln/detail/CVE-2026-35030

## Impact

This is a single-line change to `pyproject.toml` — only the pinned litellm version number. No other dependencies or code are affected.