### PR TITLE
fix(prompts): add missing quotes in aspect JSON answer format

### DIFF
--- a/.github/contributors/NikitaMok.md
+++ b/.github/contributors/NikitaMok.md
@@ -1,0 +1,60 @@
+# ContextGem contributor agreement
+
+This ContextGem Contributor Agreement (**"CCA"**) is based on the [Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf). The CCA applies to any contribution that you make to any product or project managed by us (the **"project"**), and sets out the intellectual property rights you grant to us in the contributed materials. The term **"us"** shall mean [Shcherbak AI AS](https://shcherbak.ai). The term **"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested below and include the filled-in version with your first pull request, under the folder [`.github/contributors/`](/.github/contributors/). Name your file using your GitHub username followed by the `.md` extension. For instance, if your username is example_user, you would create a file named `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code, object code, patch, tool, sample, graphic, specification, manual, documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such assignment is or becomes invalid, ineffective or unenforceable, you hereby grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge, royalty-free, unrestricted license to exercise all rights under those copyrights. This includes, at our option, the right to sublicense these same rights to third parties through multiple levels of sublicensees or other licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your contribution as if each of us were the sole owners, and if one of us makes a derivative work of your contribution, the one who makes the derivative work (or has it made) will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the consent of, pay or render an accounting to the other for any use or distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment to any third party, you hereby grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer your contribution in whole or in part, alone or in combination with or included in any product, work or materials arising out of the project to which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your contribution. The rights that you grant to us under these terms are effective on the date you first submitted a contribution to us, even if your submission took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of authorship and you can legally grant the rights set out in this CCA;
+
+    * to the best of your knowledge, each contribution will not violate any third party's copyrights, trademarks, patents, or other intellectual property rights; and
+
+    * each contribution shall be in compliance with applicable export control laws and other applicable export and import laws.
+    
+You agree to notify us if you become aware of any circumstance which would make any of the foregoing representations inaccurate in any respect. We may publicly disclose your participation in the project, including the fact that you have signed the CCA.
+
+6. This CCA is governed by the laws of Norway and applicable international law. Any choice of law rules will not apply.
+
+7. Please place an "x" on one of the applicable statement below. Please do NOT mark both statements:
+
+    * [x] I am signing on behalf of myself as an individual and no other person or entity, including my employer, has or will have rights with respect to my contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           | Nikita Mokin         |
+| Company name (if applicable)   |                      |
+| Title or role (if applicable)  |                      |
+| Date                           | 26.07.2026           |
+| GitHub username                | NikitaMok            |
+| Website (optional)             |                      |

--- a/contextgem/internal/prompts/extract_aspect_items.j2
+++ b/contextgem/internal/prompts/extract_aspect_items.j2
@@ -195,7 +195,7 @@ ANSWER FORMAT (MANDATORY):
 [
     {
         "aspect_id": str,
-        "paragraphs: [
+        "paragraphs": [
             {
                 "paragraph_id": str,
     {% if reference_depth == "sentences" %}
@@ -220,7 +220,7 @@ ANSWER FORMAT (MANDATORY):
     {
         "aspect_id": str,
     {% if reference_depth == "sentences" %}
-        "paragraphs: [
+        "paragraphs": [
             {
                 "paragraph_id": str,
                 "sentences": [
@@ -233,7 +233,7 @@ ANSWER FORMAT (MANDATORY):
             ...
         ]
     {% else %}
-        "paragraph_ids: [
+        "paragraph_ids": [
             str,
             ...
         ]


### PR DESCRIPTION
## Description

Same typo as in #86, still present in `extract_aspect_items.j2`.

Missing closing quotes in the answer format example in three places (`paragraphs` / `paragraph_ids` keys).

Concept prompt was fixed in #86; aspect prompt was not.

LLMs tend to copy the example format, so the broken JSON can lead to invalid responses / extraction errors.

Also includes my Contributor Agreement.

## Related Issues

Relates to #86

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor

## How to Test

Check the `<answer_format>` block in `contextgem/internal/prompts/extract_aspect_items.j2` — keys should be valid JSON (`"paragraphs": [`, `"paragraph_ids": [`).

Note: this changes prompt text, so aspect-related VCR cassettes may need re-recording.

## Checklist
- [x] I confirm that I have the right to submit this contribution and grant all the rights specified in the Contributor Agreement.
- [x] I have read, agreed to, filled in, and included my Contributor Agreement in `.github/contributors/[my-username].md`.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
