### PR TITLE
fix(llms): default top_p to None for Claude 4.x compatibility

### DIFF
--- a/.github/contributors/NikitaMok.md
+++ b/.github/contributors/NikitaMok.md
@@ -1,0 +1,60 @@
+# ContextGem contributor agreement
+
+This ContextGem Contributor Agreement (**"CCA"**) is based on the [Oracle Contributor Agreement](http://www.oracle.com/technetwork/oca-405177.pdf). The CCA applies to any contribution that you make to any product or project managed by us (the **"project"**), and sets out the intellectual property rights you grant to us in the contributed materials. The term **"us"** shall mean [Shcherbak AI AS](https://shcherbak.ai). The term **"you"** shall mean the person or entity identified below.
+
+If you agree to be bound by these terms, fill in the information requested below and include the filled-in version with your first pull request, under the folder [`.github/contributors/`](/.github/contributors/). Name your file using your GitHub username followed by the `.md` extension. For instance, if your username is example_user, you would create a file named `.github/contributors/example_user.md`.
+
+Read this agreement carefully before signing. These terms and conditions constitute a binding legal agreement.
+
+## Contributor Agreement
+
+1. The term "contribution" or "contributed materials" means any source code, object code, patch, tool, sample, graphic, specification, manual, documentation, or any other material posted or submitted by you to the project.
+
+2. With respect to any worldwide copyrights, or copyright applications and registrations, in your contribution:
+
+    * you hereby assign to us joint ownership, and to the extent that such assignment is or becomes invalid, ineffective or unenforceable, you hereby grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge, royalty-free, unrestricted license to exercise all rights under those copyrights. This includes, at our option, the right to sublicense these same rights to third parties through multiple levels of sublicensees or other licensing arrangements;
+
+    * you agree that each of us can do all things in relation to your contribution as if each of us were the sole owners, and if one of us makes a derivative work of your contribution, the one who makes the derivative work (or has it made) will be the sole owner of that derivative work;
+
+    * you agree that you will not assert any moral rights in your contribution against us, our licensees or transferees;
+
+    * you agree that we may register a copyright in your contribution and exercise all ownership rights associated with it; and
+
+    * you agree that neither of us has any duty to consult with, obtain the consent of, pay or render an accounting to the other for any use or distribution of your contribution.
+
+3. With respect to any patents you own, or that you can license without payment to any third party, you hereby grant to us a perpetual, irrevocable, non-exclusive, worldwide, no-charge, royalty-free license to:
+
+    * make, have made, use, sell, offer to sell, import, and otherwise transfer your contribution in whole or in part, alone or in combination with or included in any product, work or materials arising out of the project to which your contribution was submitted, and
+
+    * at our option, to sublicense these same rights to third parties through multiple levels of sublicensees or other licensing arrangements.
+
+4. Except as set out above, you keep all right, title, and interest in your contribution. The rights that you grant to us under these terms are effective on the date you first submitted a contribution to us, even if your submission took place before the date you sign these terms.
+
+5. You covenant, represent, warrant and agree that:
+
+    * Each contribution that you submit is and shall be an original work of authorship and you can legally grant the rights set out in this CCA;
+
+    * to the best of your knowledge, each contribution will not violate any third party's copyrights, trademarks, patents, or other intellectual property rights; and
+
+    * each contribution shall be in compliance with applicable export control laws and other applicable export and import laws.
+    
+You agree to notify us if you become aware of any circumstance which would make any of the foregoing representations inaccurate in any respect. We may publicly disclose your participation in the project, including the fact that you have signed the CCA.
+
+6. This CCA is governed by the laws of Norway and applicable international law. Any choice of law rules will not apply.
+
+7. Please place an "x" on one of the applicable statement below. Please do NOT mark both statements:
+
+    * [x] I am signing on behalf of myself as an individual and no other person or entity, including my employer, has or will have rights with respect to my contributions.
+
+    * [ ] I am signing on behalf of my employer or a legal entity and I have the actual authority to contractually bind that entity.
+
+## Contributor Details
+
+| Field                          | Entry                |
+|------------------------------- | -------------------- |
+| Name                           | Nikita Mokin         |
+| Company name (if applicable)   |                      |
+| Title or role (if applicable)  |                      |
+| Date                           | 26.07.2026           |
+| GitHub username                | NikitaMok            |
+| Website (optional)             |                      |

--- a/contextgem/internal/base/llms.py
+++ b/contextgem/internal/base/llms.py
@@ -3157,9 +3157,13 @@ class _DocumentLLM(_GenericLLMProcessor):
         description="Sampling temperature [0..1]; higher values increase randomness.",
     )
     top_p: StrictFloat | None = Field(
-        default=0.3,
+        default=None,
         ge=0,
-        description="Nucleus sampling [0..1]; alternative to temperature.",
+        description=(
+            "Nucleus sampling [0..1]; alternative to temperature. "
+            "Defaults to None so only temperature is sent — some providers "
+            "(e.g. Claude 4.x) reject requests that set both."
+        ),
     )
     seed: StrictInt | None = Field(
         default=None,

--- a/contextgem/public/llms.py
+++ b/contextgem/public/llms.py
@@ -108,7 +108,8 @@ class DocumentLLM(_DocumentLLM):
     :vartype reasoning_effort: ReasoningEffort | None
     :ivar top_p: Nucleus sampling value (0.0 to 1.0) controlling output focus/randomness.
         Lower values make output more deterministic, higher values produce more diverse outputs.
-        Defaults to 0.3.
+        Defaults to ``None`` (only ``temperature`` is sent). Some providers (e.g. Claude 4.x)
+        reject requests that set both ``temperature`` and ``top_p``.
     :vartype top_p: float | None
     :ivar num_retries_failed_request: Number of retries when LLM request fails. Defaults to 3.
     :vartype num_retries_failed_request: int

--- a/docs/source/llms/llm_config.rst
+++ b/docs/source/llms/llm_config.rst
@@ -149,8 +149,8 @@ The :class:`~contextgem.public.llms.DocumentLLM` class accepts the following par
      - Sampling temperature (0.0 to 1.0) controlling response creativity. Lower values produce more predictable outputs, higher values generate more varied responses.
    * - ``top_p``
      - ``float | None``
-     - ``0.3``
-     - Nucleus sampling value (0.0 to 1.0) controlling output focus/randomness. Lower values make output more deterministic, higher values produce more diverse outputs.
+     - ``None``
+     - Nucleus sampling value (0.0 to 1.0) controlling output focus/randomness. Lower values make output more deterministic, higher values produce more diverse outputs. Defaults to ``None`` so only ``temperature`` is sent by default. Some providers (e.g. Claude 4.x) reject requests that set both ``temperature`` and ``top_p``; set one of them to ``None`` when using those models.
    * - ``seed``
      - ``int | None``
      - ``None``

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1514,6 +1514,24 @@ class TestAll(TestUtils):
             temperature=None,
         )
 
+        # Default: temperature is sent, top_p is omitted (Claude 4.x rejects both)
+        llm_defaults = DocumentLLM(
+            model="openai/gpt-4o-mini",
+            api_key=os.getenv("CONTEXTGEM_OPENAI_API_KEY"),
+        )
+        assert llm_defaults.temperature == 0.3
+        assert llm_defaults.top_p is None
+        default_request_config = llm_defaults._build_request_config()
+        assert default_request_config["temperature"] == 0.3
+        assert "top_p" not in default_request_config
+
+        llm_with_top_p = DocumentLLM(
+            model="openai/gpt-4o-mini",
+            api_key=os.getenv("CONTEXTGEM_OPENAI_API_KEY"),
+            top_p=0.3,
+        )
+        assert llm_with_top_p._build_request_config()["top_p"] == 0.3
+
         # Unsupported methods
         with pytest.raises(NotImplementedError):
             self.llm_group.model_dump()


### PR DESCRIPTION
## Description

`DocumentLLM` currently defaults both `temperature=0.3` and `top_p=0.3`, so both land in the request.

Claude 4.x rejects that with a 400 (`temperature` and `top_p` cannot both be specified).

`drop_params` does not help here — both params are individually valid, it is the combination that fails.

After #52 you can already pass `top_p=None`, but out of the box Claude still fails.

This PR changes the `top_p` default to `None` (docs already describe it as an alternative to temperature), updates `llm_config` / public docstring, and adds a check in `test_init_api_llm` that the default request config includes `temperature` and omits `top_p`.

Also includes my Contributor Agreement.

## Related Issues

Relates to #52

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor

## How to Test

```bash
uv run pytest tests/test_all.py::TestAll::test_init_api_llm
```

Note: existing VCR cassettes may need re-recording where requests previously sent `top_p=0.3` by default.

## Checklist
- [x] I confirm that I have the right to submit this contribution and grant all the rights specified in the Contributor Agreement.
- [x] I have read, agreed to, filled in, and included my Contributor Agreement in `.github/contributors/[my-username].md`.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
