### PR TITLE
feat: add named OrcaRouter provider for DocumentLLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ ContextGem leverages LLMs' long context windows to deliver superior extraction a
 
 ContextGem supports both cloud-based and local LLMs through [LiteLLM](https://github.com/BerriAI/litellm) integration:
 
-- **Cloud LLMs**: OpenAI, Anthropic, Google, Azure OpenAI, xAI, and more
+- **Cloud LLMs**: OpenAI, Anthropic, Google, Azure OpenAI, xAI, OrcaRouter, and more
 - **Local LLMs**: Run models locally using providers like Ollama, LM Studio, etc.
 - **Model Architectures**: Works with both reasoning/CoT-capable (e.g. gpt-5) and non-reasoning models (e.g. gpt-4.1)
 - **Simple API**: Unified interface for all LLMs with easy provider switching

--- a/contextgem/internal/base/llms.py
+++ b/contextgem/internal/base/llms.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
+import os
 import warnings
 from collections.abc import Sequence
 from decimal import ROUND_HALF_UP, Decimal
@@ -145,6 +146,12 @@ _LOCAL_MODEL_PROVIDERS = [
     "ollama_chat/",
     "lm_studio/",
 ]
+
+# OrcaRouter is an OpenAI-compatible AI gateway; models are addressed by their
+# namespaced id (e.g. "orcarouter/auto", "openai/gpt-5.5"). See
+# https://docs.orcarouter.ai for the list of available models.
+_ORCAROUTER_MODEL_PREFIX = "orcarouter/"
+_ORCAROUTER_API_BASE = "https://api.orcarouter.ai/v1"
 
 # Rounding precision for reporting LLM costs (quantize on access only)
 _COST_QUANT = Decimal("0.00001")
@@ -3292,6 +3299,14 @@ class _DocumentLLM(_GenericLLMProcessor):
         :type __context: Any
         """
         logger.info(f"Using model {self.model}")
+
+        # OrcaRouter: apply gateway defaults before logging API configuration
+        if self.model.startswith(_ORCAROUTER_MODEL_PREFIX):
+            if self.api_base is None:
+                self.api_base = _ORCAROUTER_API_BASE
+            if self.api_key is None:
+                self.api_key = os.getenv("ORCAROUTER_API_KEY")
+
         if self.api_key is None:
             logger.info("API key was not provided. Set `api_key`, if applicable.")
         if self.api_base is None:
@@ -4168,7 +4183,9 @@ class _DocumentLLM(_GenericLLMProcessor):
         context_exceeded = False
         try:
             # Get model information to check context window
-            model_info = litellm.get_model_info(self.model)  # type: ignore[attr-defined]
+            model_info = litellm.get_model_info(  # type: ignore[attr-defined]
+                self._get_litellm_model()
+            )
             max_input_tokens = model_info.get("max_input_tokens")
 
             # If max_input_tokens is not available, skip validation
@@ -4180,7 +4197,9 @@ class _DocumentLLM(_GenericLLMProcessor):
 
             # Count tokens in the messages
             try:
-                token_count = litellm.token_counter(model=self.model, messages=messages)  # type: ignore[attr-defined]
+                token_count = litellm.token_counter(  # type: ignore[attr-defined]
+                    model=self._get_litellm_model(), messages=messages
+                )
             except Exception as e:
                 logger.warning(
                     f"Could not count tokens for model `{self.model}`: {e}. Skipping input token validation."
@@ -4231,7 +4250,9 @@ class _DocumentLLM(_GenericLLMProcessor):
         output_exceeded = False
         try:
             # Get model information to check output token limits
-            model_info = litellm.get_model_info(self.model)  # type: ignore[attr-defined]
+            model_info = litellm.get_model_info(  # type: ignore[attr-defined]
+                self._get_litellm_model()
+            )
             max_output_tokens = model_info.get("max_output_tokens")
 
             # If max_output_tokens is not available, fall back to max_tokens
@@ -4335,12 +4356,12 @@ class _DocumentLLM(_GenericLLMProcessor):
         """
 
         request_config: dict[str, Any] = {
-            "model": self.model,
+            "model": self._get_litellm_model(),
         }
 
         if self._supports_reasoning:
             model_params: list[str] | None = litellm.get_supported_openai_params(  # type: ignore[attr-defined]
-                self.model
+                self._get_litellm_model()
             )
             if model_params is not None:
                 if "max_completion_tokens" in model_params:
@@ -4884,6 +4905,27 @@ class _DocumentLLM(_GenericLLMProcessor):
             Template, _get_template("extract_concept_items")
         )
 
+    def _get_litellm_model(self) -> str:
+        """
+        Returns the model identifier as expected by LiteLLM.
+
+        OrcaRouter models (``orcarouter/...``) are translated to LiteLLM's
+        OpenAI-compatible syntax. LiteLLM strips the first ``openai/`` segment and
+        forwards the remainder to ``api_base``, so the full OrcaRouter model id
+        (e.g. ``orcarouter/auto`` or ``openai/gpt-5.5``) is preserved on the wire.
+        Bare model names (no ``/``) are re-prefixed with ``orcarouter/`` so the
+        gateway can resolve its routing channel.
+
+        :return: The LiteLLM-facing model identifier.
+        :rtype: str
+        """
+        if not self.model.startswith(_ORCAROUTER_MODEL_PREFIX):
+            return self.model
+        model_id = self.model.split("/", 1)[1]
+        if "/" not in model_id:
+            model_id = f"{_ORCAROUTER_MODEL_PREFIX}{model_id}"
+        return f"openai/{model_id}"
+
     def _set_capabilities(self) -> None:
         """
         Sets the capabilities of the LLM based on litellm.supports_*()
@@ -4892,11 +4934,12 @@ class _DocumentLLM(_GenericLLMProcessor):
         :return: None
         :rtype: None
         """
-        self._supports_vision = litellm.supports_vision(self.model)  # type: ignore[attr-defined]
-        self._supports_reasoning = litellm.supports_reasoning(self.model)  # type: ignore[attr-defined]
-        self._supports_tools = litellm.supports_function_calling(self.model)  # type: ignore[attr-defined]
+        model = self._get_litellm_model()
+        self._supports_vision = litellm.supports_vision(model)  # type: ignore[attr-defined]
+        self._supports_reasoning = litellm.supports_reasoning(model)  # type: ignore[attr-defined]
+        self._supports_tools = litellm.supports_function_calling(model)  # type: ignore[attr-defined]
         self._supports_parallel_tool_calls = litellm.supports_parallel_function_calling(  # type: ignore[attr-defined]
-            self.model
+            model
         )
 
     def _set_system_message(self) -> None:

--- a/contextgem/public/llms.py
+++ b/contextgem/public/llms.py
@@ -78,6 +78,8 @@ class DocumentLLM(_DocumentLLM):
 
     :ivar model: Model identifier in format {model_provider}/{model_name}.
         See https://docs.litellm.ai/docs/providers for supported providers.
+        OrcaRouter gateway models use the ``orcarouter/`` prefix (e.g.
+        ``orcarouter/auto``); see https://docs.orcarouter.ai for available models.
     :vartype model: str
     :ivar deployment_id: Deployment ID for the LLM. Primarily used with Azure OpenAI.
     :vartype deployment_id: str | None

--- a/dev/readme.template.md
+++ b/dev/readme.template.md
@@ -205,7 +205,7 @@ ContextGem leverages LLMs' long context windows to deliver superior extraction a
 
 ContextGem supports both cloud-based and local LLMs through [LiteLLM](https://github.com/BerriAI/litellm) integration:
 
-- **Cloud LLMs**: OpenAI, Anthropic, Google, Azure OpenAI, xAI, and more
+- **Cloud LLMs**: OpenAI, Anthropic, Google, Azure OpenAI, xAI, OrcaRouter, and more
 - **Local LLMs**: Run models locally using providers like Ollama, LM Studio, etc.
 - **Model Architectures**: Works with both reasoning/CoT-capable (e.g. gpt-5) and non-reasoning models (e.g. gpt-4.1)
 - **Simple API**: Unified interface for all LLMs with easy provider switching

--- a/dev/usage_examples/docs/llms/llm_init/llm_api.py
+++ b/dev/usage_examples/docs/llms/llm_init/llm_api.py
@@ -22,3 +22,16 @@ llm_azure_openai = DocumentLLM(
     api_base="<api_base>",
     # see DocumentLLM API reference for all configuration options
 )
+
+# Example - Using OrcaRouter AI gateway
+# OrcaRouter is an OpenAI-compatible gateway that can route requests to the best
+# model for each task. Prefix any model id with "orcarouter/" (e.g., "orcarouter/auto"
+# for automatic routing, "orcarouter/openai/gpt-5.5" to pin a specific model).
+# The API key is read from the ORCAROUTER_API_KEY environment variable when not
+# provided, and the gateway endpoint defaults to https://api.orcarouter.ai/v1.
+# See https://docs.orcarouter.ai for the list of available models.
+llm_orcarouter = DocumentLLM(
+    model="orcarouter/auto",
+    api_key="<api_key>",
+    # see DocumentLLM API reference for all configuration options
+)

--- a/docs/source/llms/supported_llms.rst
+++ b/docs/source/llms/supported_llms.rst
@@ -40,6 +40,15 @@ You can initialize cloud-based LLMs by specifying the provider and model name in
    :language: python
    :caption: Using cloud LLM providers
 
+.. note::
+   **OrcaRouter**: Any model can be routed through the `OrcaRouter <https://www.orcarouter.ai>`_
+   AI gateway by prefixing the model id with ``orcarouter/``. For example,
+   ``orcarouter/auto`` uses OrcaRouter's automatic model routing, while
+   ``orcarouter/openai/gpt-5.5`` pins a specific model behind the gateway. When no
+   ``api_key`` is provided, the ``ORCAROUTER_API_KEY`` environment variable is used,
+   and the gateway endpoint defaults to ``https://api.orcarouter.ai/v1``. See
+   `docs.orcarouter.ai <https://docs.orcarouter.ai>`_ for the list of available models.
+
 
 💻 Local LLMs
 ---------------

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1117,6 +1117,51 @@ class TestAll(TestUtils):
 
         check_locals_memory_usage(locals(), test_name="test_local_llms_vision")
 
+    def test_orcarouter_provider_config(self):
+        """
+        Tests initialization of OrcaRouter gateway models: default API base,
+        API key resolution from the ORCAROUTER_API_KEY environment variable,
+        LiteLLM model translation, and capability detection. No LLM API calls.
+        """
+
+        saved_key = os.environ.get("ORCAROUTER_API_KEY")
+        try:
+            os.environ["ORCAROUTER_API_KEY"] = "sk-orca-test-key"
+            llm = DocumentLLM(model="orcarouter/auto")
+            assert llm.api_base == "https://api.orcarouter.ai/v1"
+            assert llm.api_key == "sk-orca-test-key"
+            # Bare model names are re-prefixed so the gateway can route them
+            assert llm._get_litellm_model() == "openai/orcarouter/auto"
+            # Unknown models default to conservative capabilities (no crash)
+            assert not llm._supports_vision
+        finally:
+            if saved_key is None:
+                os.environ.pop("ORCAROUTER_API_KEY", None)
+            else:
+                os.environ["ORCAROUTER_API_KEY"] = saved_key
+
+        # Explicit api_base/api_key are preserved
+        llm_custom = DocumentLLM(
+            model="orcarouter/auto",
+            api_base="https://custom.example/v1",
+            api_key="sk-orca-custom",
+        )
+        assert llm_custom.api_base == "https://custom.example/v1"
+        assert llm_custom._get_litellm_model() == "openai/orcarouter/auto"
+
+        # Pinned namespaced models keep their full id on the wire and inherit
+        # capability detection from the underlying model
+        llm_pinned = DocumentLLM(
+            model="orcarouter/openai/gpt-5.5", api_key="sk-orca-custom"
+        )
+        assert llm_pinned._get_litellm_model() == "openai/openai/gpt-5.5"
+        assert llm_pinned._supports_vision
+
+        # Non-OrcaRouter models are passed through unchanged
+        llm_plain = DocumentLLM(model="openai/gpt-4.1-mini", api_key="sk-test")
+        assert llm_plain._get_litellm_model() == "openai/gpt-4.1-mini"
+        assert llm_plain.api_base is None
+
     @pytest.mark.vcr
     @memory_profile_and_capture
     def test_llm_extraction_error_exception(self):


### PR DESCRIPTION
## Description

Adds [OrcaRouter](https://www.orcarouter.ai) as a named provider. With one API key, users get 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single endpoint. Because the `orcarouter/` model prefix is a thin base-URL swap on the existing LiteLLM integration, any ContextGem document pipeline or agent that uses it also inherits OrcaRouter's gateway-level, zero-trust security controls for AI agents — with no application code changes. The gateway screens every prompt and response and governs every tool call on a default-deny basis, across four layers:

- **Scoped keys** — bind a key to specific models, IPs, spend caps, and expiry.
- **Guardrails** — screen for PII, secret leakage, prompt injection, and unsafe output.
- **Agent firewall** — tool allow-lists with per-argument validation.
- **Audit trail** — a record of every match, verdict, and approval decision.

I'm an engineer on the OrcaRouter team.

### What this PR does

- Adds a named `orcarouter/` provider to `DocumentLLM`. Any model id prefixed with `orcarouter/` (e.g. `orcarouter/auto` for automatic routing, `orcarouter/openai/gpt-5.5` to pin a specific model) is routed through the OrcaRouter gateway.
- When no `api_base` is set, defaults to `https://api.orcarouter.ai/v1`; when no `api_key` is set, falls back to the `ORCAROUTER_API_KEY` environment variable.
- Translates LiteLLM-facing model ids to `openai/<gateway-id>` so the full namespaced OrcaRouter model id is preserved on the wire. Capability detection (vision/reasoning/tool-calling) follows the underlying model where pinned; unknown router ids default to conservative capabilities, with the existing manual `_supports_*` override as the escape hatch.
- Adds a unit test (`test_orcarouter_provider_config`) covering gateway defaults, environment key resolution, model translation, and capability detection.
- Documents the provider in the README, the supported-LLMs docs, the `DocumentLLM` API reference, and the cloud-LLM usage example.

## Related Issues

None.

## Types of change

- [x] New feature (non-breaking change which adds functionality)

## How to Test

1. `uv run pre-commit run --all-files` — all hooks pass (ruff, ty, bandit, markdownlint, interrogate, deptry, README/notebook regeneration, package check).
2. `uv run pytest tests/test_all.py::TestAll::test_orcarouter_provider_config` — passes (no LLM API calls).
3. Live check against the gateway (real key): `DocumentLLM(model="orcarouter/auto", max_tokens=64).chat("Reply with exactly one word: PONG")` returns `PONG` via `https://api.orcarouter.ai/v1`.

## Checklist

- [ ] I confirm that I have the right to submit this contribution and grant all the rights specified in the Contributor Agreement. *(Pending — signing the Contributor Agreement is a legal act performed by the contributor; I have deliberately not created `.github/contributors/XiaoHuo888-hue.md` in this PR. Happy to add it as soon as the maintainers confirm, or the author will sign it separately.)*
- [ ] I have read, agreed to, filled in, and included my Contributor Agreement in `.github/contributors/[my-username].md`.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
